### PR TITLE
Add support for Lean

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -101,6 +101,8 @@ let languages : Language[] = [|
         java
     lang "LaTeX" "tex" ".bbx|.cbx|.cls|.sty|.tex"
         Latex.latex
+    lang "Lean" "" ".lean"
+        ( sourceCode [ line "--"; block ( "/-[-!]?", "-/" ) ] )
     lang "Less" "" ".less"
         java
     lang "Lua" "" ".lua"


### PR DESCRIPTION
Lean documentation: [Normal comments](https://leanprover.github.io/reference/lexical_structure.html#lexical-structure), [Doc comments](https://leanprover.github.io/reference/lexical_structure.html#doc-comments)

I haven't tested this (I don't have an environment setup), so if you could sanity check this that'd be awesome.