### PR TITLE
add Crystal (.cr) language support

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -61,6 +61,8 @@ let languages : Language[] = [|
               line "#"
             ]
         )
+    lang "Crystal" "" ".cr"
+        ( sourceCode [ line "#"; block ( "=begin", "=end" ) ] )
     lang "CSS" "" ".css"
         css
     // Special rules for DDoc need adding


### PR DESCRIPTION
Crystal is a language that is syntactically similar to Ruby.
This adds support for it using the same configuration as Ruby.