### PR TITLE
Add support for rewrapping Bikeshed like Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ configuring settings and keybindings.
 
 The full list of types currently supported is:
 
-AutoHotKey, Bash/shell script, Batch/cmd file, C, C#, C++, CoffeeScript,
-Crystal, CSS, D (partial), Dart, Docker file, Elixir, Elm, F#, Go, GraphQL,
-Groovy, Haskell, HCL, Html, Ini, Jade, Java, JavaScript, LaTeX, Lean, Less, Lua,
-Makefile, Markdown, MATLAB, Objective-C, Perl, PHP, PowerShell, Protobuf,
-PureScript, Python, R, Ruby, Rust, Sass, SQL, Swift, Tcl, Terraform, Toml,
-TypeScript, Visual Basic, Xml, Xsl, Yaml.
+AutoHotKey, Bash/shell script, Batch/cmd file, Bikeshed, C, C#, C++,
+CoffeeScript, Crystal, CSS, D (partial), Dart, Docker file, Elixir, Elm, F#, Go,
+GraphQL, Groovy, Haskell, HCL, Html, Ini, Jade, Java, JavaScript, LaTeX, Lean,
+Less, Lua, Makefile, Markdown, MATLAB, Objective-C, Perl, PHP, PowerShell,
+Protobuf, PureScript, Python, R, Ruby, Rust, Sass, SQL, Swift, Tcl, Terraform,
+Toml, TypeScript, Visual Basic, Xml, Xsl, Yaml.
 
 For any other type of file, plain-text paragraph wrapping is still supported.
 

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -44,6 +44,8 @@ let languages : Language[] = [|
         ( sourceCode [ customLine html "'''"; line "'" ] )
     lang "Batch file" "bat" ".bat"
         ( sourceCode [ line "(?:rem|::)" ] )
+    lang "Bikeshed" "bikeshed" ".bs"
+        Markdown.markdown
     lang "C/C++" "c|c++|cpp" ".c|.cpp|.h"
         java
     lang "C#" "csharp" ".cs"


### PR DESCRIPTION
Bikeshed (https://tabatkins.github.io/bikeshed/) is a
specification-generating tool that takes markdown-like text as input.