### PR TITLE
Fix #104 - Add Prolog support

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -159,6 +159,8 @@ let languages : Language[] = [|
         )
     lang "PowerShell" "" ".ps1|.psd1|.psm1"
         ( sourceCode [ customLine psdoc "#"; customBlock psdoc ( "", "" ) ( "<#", "#>" ) ] )
+    lang "Prolog" "" ".pl"
+        ( sourceCode [ line "%"; cBlock ] )
     lang "Protobuf" "proto|proto3" ".proto"
         ( sourceCode [ cLine ] )
     lang "Pug" "jade" ".jade|.pug"

--- a/specs/DocTypes/Prolog.md
+++ b/specs/DocTypes/Prolog.md
@@ -1,0 +1,8 @@
+> language: "prolog"
+
+    % a b c      ->        % a b ¦
+    % d   ¦                % c d ¦
+
+    /* a b c     ->        /* a b  ¦
+       d   ¦                  c d  ¦
+    */     ¦               */      ¦


### PR DESCRIPTION
This adds support for Prolog files, which use line comments of `%` and C-styled block comments. I've included a test in the spec, and also tested the extension locally.

