### PR TITLE
Add basic Verilog and SystemVerilog support

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -193,11 +193,15 @@ let languages : Language[] = [|
         ( sourceCode [ line "--"; cBlock ] )
     lang "Swift" "" ".swift"
         java
+    lang "SystemVerilog" "" ".sv|.svh"
+        java
     lang "Tcl" "" ".tcl"
         configFile
     lang "TOML" "" ".toml"
         configFile
     lang "TypeScript" "typescriptreact" ".ts|.tsx"
+        java
+    lang "Verilog" "" ".v|.vh"
         java
     lang "XML" "xsl" ".xml|.xsl"
         html


### PR DESCRIPTION
Verilog and SystemVerilog use C/Java style comments. Add them to the supported list of languages using the Java parser.