### PR TITLE
Fixes LaTeX rewrap to not include comments

### DIFF
--- a/core/Parsing.Latex.fs
+++ b/core/Parsing.Latex.fs
@@ -99,6 +99,10 @@ let private findPreserveSection beginMarker : Lines -> Blocks * Option<Lines> =
         )
     )
 
+let private hasComment line : bool =
+    let r = Regex(@"[^\\]%")
+    let commentMatch = r.Match(line)
+    commentMatch.Success
 
 let latex (settings: Settings) : TotalParser =
 
@@ -121,6 +125,11 @@ let latex (settings: Settings) : TotalParser =
             Some (findPreserveSection trimmedLine lines)
         else if cmdName = "begin" && Array.contains cmdArg preserveEnvironments then
             Some (findPreserveSection cmdArg lines)
+
+        // Line ends with comment: do not wrap before that
+        else if hasComment trimmedLine
+        then
+            Some (takeFrom2ndLineUntil otherParsers plainText lines)
 
         // Whole line is command: preserve break before & after
         else if isWholeLine then

--- a/specs/DocTypes/LaTeX.md
+++ b/specs/DocTypes/LaTeX.md
@@ -74,3 +74,19 @@ The shortcuts `\( \[ $ $$` create a preserved section.
     $$                ¦              $$                ¦
     a b c d e f g h   ¦              a b c d e f g h i ¦
     i j               ¦              j                 ¦
+
+## End-of-line comments
+
+In general, like for all languages, end-of-line comments are not properly
+supported. But a line-break after comment that comes after text on the same line
+will be preserved.
+
+    a b c d e f g h   ¦      ->      a b c d e f g h i ¦
+    i j % z y x       ¦              j % z y x         ¦
+    k l m             ¦              k l m             ¦
+
+Long comments cannot yet be wrapped, however.
+
+    a b c d e f g h   ¦          ->      a b c d e f g h i ¦
+    i j % z y x w v u t s r              j % z y x w v u t s r
+    k l m             ¦                  k l m             ¦


### PR DESCRIPTION
Former version did not have a robust handling of comments, see #148