### PR TITLE
Support new v1.43 VSCode ruler objects

### DIFF
--- a/vscode/Settings.js
+++ b/vscode/Settings.js
@@ -27,7 +27,10 @@ function getWrappingColumns(setting)
     if(extensionColumn = setting('rewrap.wrappingColumn'))
         return [extensionColumn]
     else if((rulers = setting('editor.rulers'))[0])
-        return rulers
+        // Rulers might be {"column": 80, "color": "#000000"} objects
+        return rulers.map(
+            (ruler) => Number.isInteger(ruler) ? ruler : ruler.column
+        )
     else
         return [setting('editor.wordWrapColumn')]
         // The default for this is already 80


### PR DESCRIPTION
From v1.43 of VSCode the previous `editor.rulers` (for either general or language-specific) has been changed to also accept the following object which takes in a specific color for each ruler:
`{"column": 80, "color": "#ff4081"}`

The Rewrap extension only had support for the number rulers, so this commit changes that. It takes care of figuring out if the ruler is using the bare number or the new object, and if using the object, will convert it down to just the column number to keep the rest of the code as is.

More info on this on:
* v1.43 release notes: https://code.visualstudio.com/updates/v1_43#_multiple-rulers-with-different-colors
* Issue for this topic: https://github.com/microsoft/vscode/issues/54312
* PR that added this change: https://github.com/microsoft/vscode/pull/88453