### PR TITLE
Add support for Clojure, Common Lisp, Emacs Lisp, Scheme, and J

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ See also [https://github.com/stkb/vscode-rewrap/releases](https://github.com/stk
 
 ## Unreleased
 
+- Add Clojure, Common Lisp, Emacs Lisp, Scheme, and J (#246, #240)
 - Fix per-language settings sometimes not applying.
 - Declare as a UI extension so it doesn't have to be installed in the remote
   workspace (#231); fixes locally-installed language extensions not being found

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -64,11 +64,19 @@ let mutable languages = [
         )
     lang "CMake" "" "CMakeLists.txt"
         configFile
+    lang "Clojure" "" ".clj|.cljs|.cljc|.cljx|.edn"
+        ( sourceCode [ line ";+" ] )
     lang "CoffeeScript" "" ".coffee"
         ( sourceCode
             [ customBlock javadoc ("*#", " * ") ( "###\\*", "###" )
               block ( "###", "###" )
               line "#"
+            ]
+        )
+    lang "Common Lisp" "commonlisp|lisp" ".lisp"
+        ( sourceCode
+            [ line ";+"
+              block ( @"#\|", @"\|#" )
             ]
         )
     lang "Configuration" "properties" ".conf|.gitconfig"
@@ -102,6 +110,8 @@ let mutable languages = [
         ( sourceCode [ line "#"; block ("@(module|type|)doc\s+\"\"\"", "\"\"\"") ] )
     lang "Elm" "" ".elm"
         ( sourceCode [ line "--"; block ( "{-\|?", "-}" ) ] )
+    lang "Emacs Lisp" "elisp|emacslisp" ".el"
+        ( sourceCode [ line ";+" ] )
     lang "F#" "fsharp" ".fs|.fsx"
         ( sourceCode
             [ customLine xmldoc "///"; cLine;
@@ -144,6 +154,8 @@ let mutable languages = [
         html
     lang "INI" "" ".ini"
         ( sourceCode [ line "[#;]" ] )
+    lang "J" "" ".ijs"
+        ( sourceCode [ line @"NB\." ] )
     lang "Java" "" ".java"
         java
     lang "JavaScript" "javascriptreact|js" ".js|.jsx"
@@ -230,6 +242,12 @@ let mutable languages = [
         java
     lang "Scala" "" ".scala"
         java
+    lang "Scheme" "" ".scm|.ss|.sch|.rkt"
+        ( sourceCode
+            [ line ";+"
+              block ( @"#\|", @"\|#" )
+            ]
+        )
     lang "Shaderlab" "" ".shader"
         java
     lang "Shell script" "shellscript" ".sh"

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -62,10 +62,10 @@ let mutable languages = [
               customBlock javadoc ( "*", " * " ) javadocMarkers; cBlock
             ]
         )
-    lang "CMake" "" "CMakeLists.txt"
-        configFile
     lang "Clojure" "" ".clj|.cljs|.cljc|.cljx|.edn"
         ( sourceCode [ line ";+" ] )
+    lang "CMake" "" "CMakeLists.txt"
+        configFile
     lang "CoffeeScript" "" ".coffee"
         ( sourceCode
             [ customBlock javadoc ("*#", " * ") ( "###\\*", "###" )


### PR DESCRIPTION
Fixes #240

I used the pattern `;+` since it is the convention in Lisp to use a different number of semicolons depending on the type of comment.

Common Lisp and Scheme additionally have `#| ... |#` block comments.

J uses `NB.` for line comments.