### PR TITLE
Add "Unwrap Comment / Text" command

### DIFF
--- a/docs/keybindings-vscode.md
+++ b/docs/keybindings-vscode.md
@@ -16,6 +16,14 @@ To add a keybinding for the **Wrap Comment / Text at column...** command, use it
 }
 ```
 
+### Unwrap command ###
+To add a keybinding for the **Unwrap Comment / Text** command, use its `rewrap.unwrapComment` id:
+```json5
+{
+  "key": "alt+shift+q", "command": "rewrap.unwrapComment"
+}
+```
+
 ### Auto-wrap command ###
 To add a keybinding for the auto-wrap toggle, use the command ID `rewrap.toggleAutoWrap`.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -47,6 +47,10 @@
         "title": "Rewrap Comment / Text"
       },
       {
+        "command": "rewrap.unwrapComment",
+        "title": "Unwrap Comment / Text"
+      },
+      {
         "command": "rewrap.rewrapCommentAt",
         "title": "Rewrap/Unwrap Text At Column..."
       },

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -13,6 +13,7 @@ async function activate(context) {
     // Register the commands
     context.subscriptions.push
         ( commands.registerTextEditorCommand('rewrap.rewrapComment', rewrapCommentCommand)
+        , commands.registerTextEditorCommand('rewrap.unwrapComment', unwrapCommentCommand)
         , commands.registerTextEditorCommand('rewrap.rewrapCommentAt', rewrapCommentAtCommand)
         , commands.registerTextEditorCommand('rewrap.toggleAutoWrap', autoWrap.editorToggle)
         )
@@ -21,6 +22,12 @@ async function activate(context) {
     function rewrapCommentCommand(editor)
     {
         doWrap(editor).then(() => saveDocState(getDocState(editor)))
+    }
+
+    /** Unwrap command */
+    function unwrapCommentCommand(editor)
+    {
+        doWrap(editor, 0).then(() => saveDocState(getDocState(editor)))
     }
 
     let customWrappingColumn = 0;


### PR DESCRIPTION
Unwrapping is possible with the "Rewrap/Unwrap Text At Column...",
but requires a second step of manual input then.

Adding a dedicated unwrap command avoids the prompt and makes it
possible to keybind the action.