### PR TITLE
[Markdown] Add support for YAML Header

### DIFF
--- a/core/Parsing.Markdown.fs
+++ b/core/Parsing.Markdown.fs
@@ -247,7 +247,7 @@ let private blockQuoteRegex =
     mdMarker ">"
 
 let private fencedCodeBlockRegex =
-    mdMarker "(`{3,}|~{3,})"
+    mdMarker "(`{3,}|~{3,}|-{3})"
 
 let private lineStartsWith =
         Line.contains << mdMarker
@@ -272,13 +272,13 @@ let private findListItemEnd indent: MarkdownState -> List<string> -> List<string
             // Need to fix fencedCodeBlock start/end markers
             match state with
                 | FencedCodeBlock ->
-                    if lineStartsWith "(```|~~~)" line then
+                    if lineStartsWith "(```|~~~|---)" line then
                         NonParagraph
                     else
                         FencedCodeBlock
 
                 | Paragraph ->
-                    if lineStartsWith "(```|~~~)" line then
+                    if lineStartsWith "(```|~~~|---)" line then
                         FencedCodeBlock
                     else if not (Line.containsText line) || lineStartsWith "#{1,6} " line then
                         NonParagraph
@@ -286,7 +286,7 @@ let private findListItemEnd indent: MarkdownState -> List<string> -> List<string
                         Paragraph
 
                 | NonParagraph ->
-                    if lineStartsWith "(```|~~~)" line then
+                    if lineStartsWith "(```|~~~|---)" line then
                         FencedCodeBlock
                     else if not (Line.containsText line) || lineStartsWith "#{1,6} " line then
                         NonParagraph

--- a/specs/Detail/Markdown-YAML-Header.md
+++ b/specs/Detail/Markdown-YAML-Header.md
@@ -1,0 +1,22 @@
+> language: "markdown"
+
+# Basic YAML Header must stay intact
+
+    ---                              ¦    ->      ---  ¦
+    uid:                             ¦            uid: ¦
+    title: "High Level Architecture" ¦            title: "High Level Architecture" ¦
+    ---                              ¦            ---  ¦
+
+# YAML Header with embedded items must stay intact
+
+    ---                    ¦              ---  ¦
+    md_files:              ¦              md_files: ¦
+      - 00-index.md        ¦                - 00-index.md ¦
+      - 01-introduction.md ¦      ->        - 01-introduction.md ¦
+    ---                    ¦              ---  ¦
+
+# YAML Header with list of items must stay intact
+
+    ---                                             ¦              ---  ¦
+    md_files: ["00-index.md", "01-introduction.md"] ¦      ->      md_files: ["00-index.md", "01-introduction.md"] ¦
+    ---                                             ¦              ---  ¦


### PR DESCRIPTION
Hi @stkb !

Thanks for that great extension!

I currently use Markdown files with DocFx to generate documentation and YAML Header helps me keep extra information on markdown files.  

Without this fix, rewrap generate something similar to that:

```
    ---                              ¦    ->      ---  ¦
    uid:                             ¦            uid: title: "High Level Architecture" ¦
    title: "High Level Architecture" ¦            ---  ¦            
    ---                              ¦            
```

So I created that PR to allow me to fully use your extension on whole documents. 

Tests execution output:

```
(rewrap) C:\Code\GitHub\Rewrap>do test

Running Core tests
Passed: 249; Failed: 0; Errored: 0


(rewrap) C:\Code\GitHub\Rewrap>
```

Thanks.