### PR TITLE
Add Julia multiline comment support

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -154,7 +154,7 @@ let mutable languages = [
         java
     lang "JavaScript" "javascriptreact|js" ".js|.jsx"
         java
-    lang "Julia" "" ".jl" <| sc [line "#"; block (@".*?""""""", "\"\"\"")]
+    lang "Julia" "" ".jl" <| sc [block ("#=", "=#"); line "#"; block (@".*?""""""", "\"\"\"")]
     lang "JSON" "json5|jsonc" ".json|.json5|.jsonc"
         java
     lang "LaTeX" "tex" ".bbx|.cbx|.cls|.sty|.tex"

--- a/docs/specs/content-types/julia.md
+++ b/docs/specs/content-types/julia.md
@@ -20,3 +20,14 @@ This can also be preceeded by the `@doc` macro
     a b c d e f g            a b c d e f
     h i        ¦             g h i      ¦
     """        ¦             """        ¦
+
+
+It also has `#` line comments and `#= =#` block comments.
+
+    # a b c                           ->      # a b ¦
+    # d   ¦                                   # c d ¦
+
+    #=  ¦                                     #=  ¦
+    a b c                             ->      a b ¦
+    d   ¦                                     c d ¦
+    =#  ¦                                     =#  ¦


### PR DESCRIPTION
Fixes #302.

Couldn't actually test as running the extension yielded `no such file or directory, stat 'core/test/../dist/dev/Tests.js'`
(I did run `npm install` and download .net 6.0 sdk before. Anything else I'd need to do? I know nothing about F# development or vs code extensions for that matter).
(Ah, problem is probably that I'm on windows, and that `/../` path doesn't work).