### PR TITLE
Add support for GN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ See also [https://github.com/stkb/vscode-rewrap/releases](https://github.com/stk
 
 ---
 
+### Unreleased
+
+- Add GN language (#342)
+
 
 ### 1.16.3
 

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -133,6 +133,7 @@ let mutable languages = [
             ]
         )
     lang "Git commit" "git-commit" "tag_editmsg" <| docOf markdown
+    lang "GN" "" ".gn|.gni" <| configFile
     lang "GraphQL" "" ".graphql|.gql" <| sc [line "#"; block (@".*?""""""", "\"\"\"")]
     lang "Groovy" "" ".groovy"
         java


### PR DESCRIPTION
GN is a build system used by Chromium and some other projects: https://gn.googlesource.com/gn/

It uses `#` for comments: https://gn.googlesource.com/gn/+/main/docs/reference.md#white-space-and-comments