### PR TITLE
Add Quarto (.qmd) as Markdown

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -199,6 +199,7 @@ let mutable languages = [
     // it wasn't intended.
     lang "PureScript" "" ".purs" <| sc [line "--\s*\|"; line "--"; block ("{-\s*\|?", "-}")]
     lang "Python" "" ".py" <| sc [line "#"; block' ("","") (@"(.*?)""""""", "\"\"\"") rst; block' ("","") (@"(.*?)'''", "'''") rst]
+    lang "Quarto" "" ".qmd" <| docOf markdown
     lang "R" "" ".r" <| sc [line "#'?"]
     lang "reStructuredText" "rst" ".rst|.rest" <| docOf rst
     lang "Ruby" "" ".rb" <| sc [line "#"; block ("=begin", "=end")]


### PR DESCRIPTION
Add Quarto documents (`.qmd`) as Markdown-typs docs for wrapping and processing.