### PR TITLE
Add Zig support

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -228,11 +228,17 @@ let mutable languages = [
     lang "XML" "xsl" ".xml|.xsl"
         html
     lang "YAML" "" ".yaml|.yml"
-        /// Also allow text paragraphs to be wrapped. Though wrapping the whole
-        /// file at once will mess it up.
+        // Also allow text paragraphs to be wrapped. Though wrapping the whole
+        // file at once will mess it up.
         <| toNewDocProcessor (fun settings ->
             let comments = oldLine "#{1,3}" settings
             takeUntil comments (oldPlainText settings) |> repeatToEnd)
+    lang "Zig" "" ".zig|.zon"
+        ( oldSourceCode
+            [ customLine DocComments.javadoc "//[/!]"
+              cLine
+            ]
+        )
     ]
 
 /// Creates a custom language parser, if the given CustomMarkers are valid. Also

--- a/core/Tests.fs
+++ b/core/Tests.fs
@@ -271,7 +271,7 @@ type Results = {passes:int; failures:int; errors:int}
 
 [<EntryPoint>]
 let main argv =
-  let norm (s: String) = s.ToLower().Replace('\\', '/')
+  let norm (s: String) = s.Replace('\\', '/')
   let argv = Array.map norm argv
   let inArgv (f: string) = argv |> Array.exists (fun a -> f.EndsWith (a))
   let filesToTest =

--- a/docs/specs/content-types/zig.md
+++ b/docs/specs/content-types/zig.md
@@ -1,0 +1,17 @@
+> language: "zig"
+
+Zig uses comment formats that might be familiar if you use Doxygen (C/C++) but there are
+no multi-line block comments.
+
+    // a b c       ->      // a b ¦
+    // d   ¦               // c d ¦
+
+Doc comments:
+
+    /// a b c       ->      /// a b ¦
+    /// d   ¦               /// c d ¦
+
+Top-level doc comments:
+
+    //! a b c       ->      //! a b ¦
+    //! d   ¦               //! c d ¦

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@typescript-eslint/parser": "^5.12.0",
     "eslint": "^8.9.0",
     "log-update": "^5.0.0",
-    "parcel": "^2.3.2",
+    "parcel": "^2.10.2",
     "typescript": "^4.5.5",
     "vsce": "^2.6.7",
     "vscode-test": "^1.6.1"


### PR DESCRIPTION
Add Zig support, https://ziglang.org/documentation/0.11.0/#Comments

Fix https://github.com/stkb/Rewrap/issues/388

Tests pass and tested the extension in VSCode :white_check_mark: 


### Dev notes

#### Setup

Using Node.js `v18.16.0`

Install depdencies
```
$ npm install
```

Make sure `dotnet` is installed (see section below for more details)


#### Testing

```sh
$ node .config/do.mjs test
```

#### Building

```sh
$ node .config/do.mjs package
Core build complete. Running tests:...
Passed: 473; Failed: 0; Errored: 0
Creating VSIX...
 WARNING  Using '*' activation is usually a bad idea as it impacts performance.
VSIX file created at .obj/Rewrap-VSCode.vsix
```

Install the extension in VSCode (this will just overwrite whatever version of Rewrap you already have installed):

```sh
$ code --install-extension .obj/Rewrap-VSCode.vsix
Installing extensions...
(node:310226) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `code --trace-deprecation ...` to show where the warning was created)
Extension 'Rewrap-VSCode.vsix' was successfully installed.
```

---

Other build commands for reference:

```sh
$ node .config/do.mjs build
$ node .config/do.mjs build vscode
```



#### Installing `dotnet` dependency

 1. [Download and install the .NET Core SDK](https://dotnet.microsoft.com/en-us/download) for your platform (tested with .NET 6). For me this looked like the following:
    ```sh
    $ cd ~/Downloads/
    $ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
    $ chmod +x ./dotnet-install.sh
    $ ./dotnet-install.sh
    dotnet-install: Attempting to download using aka.ms link https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.415/dotnet-sdk-6.0.415-linux-x64.tar.gz
    dotnet-install: Remote file https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.415/dotnet-sdk-6.0.415-linux-x64.tar.gz size is 186298830 bytes.
    dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.415/dotnet-sdk-6.0.415-linux-x64.tar.gz
    dotnet-install: Downloaded file size is 186298830 bytes.
    dotnet-install: The remote and local file sizes are equal.
    dotnet-install: Installed version is 6.0.415
    dotnet-install: Adding to current process PATH: `/home/eric/.dotnet`. Note: This change will be visible only when sourcing script.
    dotnet-install: Note that the script does not resolve dependencies during installation.
    dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
    dotnet-install: Installation finished successfully.
    ```
 1. [Update your `$PATH` environment variable](https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#set-environment-variables-system-wide) so you can access `dotnet` from the CLI:
    `.bashrc`
    ```sh
    # For .NET dotnet, C# (csharp)
    # https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#set-environment-variables-system-wide
    export DOTNET_ROOT=~/.dotnet
    # export MSBuildSDKsPath=$DOTNET_ROOT/sdk/$(${DOTNET_ROOT}/dotnet --version)/Sdks
    export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
    ```
