### PR TITLE
Feature: support OCaml block comments

### DIFF
--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -170,7 +170,7 @@ let mutable languages = [
     lang "MATLAB" "" "" <| sc [line "%(?![%{}])"; block ("%\{", "%\}")]
     lang "Objective-C" "" ".m|.mm"
         java
-    lang "OCaml" "ocaml|ocaml.interface" ".ml|.mli" <| sc [block (@"(\(\* )", @"\*\)")]
+    lang "OCaml" "ocaml|ocaml.interface" ".ml|.mli" <| sc [block (@"(\(\*+_? )", @"\*\)")]
     lang "Octave" "" "" <| sc [block ("#\{", "#\}"); block ("%\{", "%\}"); line "##?"; line "%[^!]"]
     lang "Pascal" "delphi" ".pas" <| sc [block (@"\(\*", @"\*\)"); block (@"\{(?!\$)", @"\}"); line "///?"]
     // Putting Perl & Perl6 together. Perl6 also has a form of block comment which still

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -170,6 +170,7 @@ let mutable languages = [
     lang "MATLAB" "" "" <| sc [line "%(?![%{}])"; block ("%\{", "%\}")]
     lang "Objective-C" "" ".m|.mm"
         java
+    lang "OCaml" "ocaml|ocaml.interface" ".ml|.mli" <| sc [block (@"(\(\* )", @"\*\)")]
     lang "Octave" "" "" <| sc [block ("#\{", "#\}"); block ("%\{", "%\}"); line "##?"; line "%[^!]"]
     lang "Pascal" "delphi" ".pas" <| sc [block (@"\(\*", @"\*\)"); block (@"\{(?!\$)", @"\}"); line "///?"]
     // Putting Perl & Perl6 together. Perl6 also has a form of block comment which still

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -170,7 +170,7 @@ let mutable languages = [
     lang "MATLAB" "" "" <| sc [line "%(?![%{}])"; block ("%\{", "%\}")]
     lang "Objective-C" "" ".m|.mm"
         java
-    lang "OCaml" "ocaml|ocaml.interface" ".ml|.mli" <| sc [block (@"(\(\*+_? )", @"\*\)")]
+    lang "OCaml" "ocaml|ocaml.interface" ".ml|.mli" <| sc [block (@"(.*\(\*+_? )", @"\*\)")]
     lang "Octave" "" "" <| sc [block ("#\{", "#\}"); block ("%\{", "%\}"); line "##?"; line "%[^!]"]
     lang "Pascal" "delphi" ".pas" <| sc [block (@"\(\*", @"\*\)"); block (@"\{(?!\$)", @"\}"); line "///?"]
     // Putting Perl & Perl6 together. Perl6 also has a form of block comment which still


### PR DESCRIPTION
Support OCaml comments of the following forms
```
(* comment/docstring *)
(** docstring *)
(*_ interface comment *)
```
with space-preserving line-wrapping behavior (the next line is alined with the first space after `(*`) 